### PR TITLE
Fix bottle CVE: bump to 0.13.4 in setup/requirements.txt

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,5 +1,5 @@
 Unidecode==0.4.20
-bottle==0.12.13
+bottle==0.13.4
 email-validator==1.0.2
 fuzzywuzzy==0.15.0
 pymongo==3.4.0


### PR DESCRIPTION
## Summary
Closes the two critical Dependabot alerts for **GHSA-xhp9-4947-rq78** ("Denial of service in bottle", bottle < 0.12.20).

Investigation:
- `pyproject.toml` already requires `bottle = "^0.13.4"` (patched).
- `poetry.lock` already resolves to `bottle 0.13.4` (patched) — alert #16 against the lock file appears stale and should auto-close after this lands.
- `setup/requirements.txt` still pins `bottle==0.12.13` (vulnerable). **This PR fixes that.**
- The root-level (poetry-exported) `requirements.txt` has `bottle==0.12.25`, which is already above the patched floor of 0.12.20 — not flagged, no change needed.

## Diff
```diff
- bottle==0.12.13
+ bottle==0.13.4
```

## Test plan
- [ ] After merge, confirm both critical Dependabot alerts (#2 and #16) auto-close.
- [ ] `setup/requirements.txt` is older / less-canonical than `pyproject.toml`. Confirm nothing in the deploy still installs from it (DEPLOY_HOURLY doesn't reference it; couldn't find other consumers). If it's genuinely unused, a follow-up could just delete it — that would knock out a chunk of the remaining high/moderate Dependabot alerts which mostly target this file's old `pymongo==3.4.0` / `requests==2.20.0` / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)