### PR TITLE
Remove orphaned setup/requirements.txt

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,8 +1,0 @@
-Unidecode==0.4.20
-bottle==0.13.4
-email-validator==1.0.2
-fuzzywuzzy==0.15.0
-pymongo==3.4.0
-requests==2.20.0
-titlecase==0.10.0
-xlwt==1.2.0


### PR DESCRIPTION
## Summary
Deletes `setup/requirements.txt`, which is unreferenced and years out of date.

## Why it's safe
Audit summary (`grep`-based, repo-wide, excluding `.venv`/`.git`):

| Check | Result |
|---|---|
| Any tracked script/cron/Dockerfile/Makefile references the file | ❌ no match |
| `pip install -r setup/requirements.txt` invocation anywhere | ❌ no match |
| `DEPLOY_HOURLY` uses it | ❌ doesn't reference it |
| Versions match canonical `pyproject.toml` | ❌ drastically stale |
| All 8 packages are still real deps | ❌ `titlecase` (no imports) and `email-validator` (only commented-out) aren't even in `pyproject.toml` |

Concrete version drift vs. `pyproject.toml` / poetry lock:
- `Unidecode` 0.4.20 (2014) vs 1.3.6
- `pymongo` 3.4.0 (2017) vs 3.13.0
- `requests` 2.20.0 vs 2.31.0
- `fuzzywuzzy` 0.15.0 vs 0.18.0
- `xlwt` 1.2.0 vs 1.3.0

Canonical dependency specs already live in `pyproject.toml` (specs) + `poetry.lock` (resolved versions), with hash-pinned `requirements.txt` at repo root for non-poetry installs.

## Impact
Closes 7 open Dependabot alerts targeting this file (1 critical bottle + 6 medium across requests/pymongo/older bottle). No deployed dependency actually changes.

## Test plan
- [ ] Confirm via search history that nothing on a deployment server (outside this repo) installs from `setup/requirements.txt`. The grep audit covers this repo; if there's an external deploy script that uses it, that would need to switch to `requirements.txt` (root) or poetry.
- [ ] After merge, check the Dependabot tab: alerts #1, #11, #12, #13, #14 should auto-close (alerts #2 and #4 were already closed by PR #435 + earlier merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)