### PR TITLE
Sink votes without a probability estimate to the bottom of the sort

### DIFF
--- a/model/prep_votes.py
+++ b/model/prep_votes.py
@@ -198,13 +198,17 @@ def sort_votes_by_column(votes, sort_col, sort_dir):
         order = {"Yea": 3, "Nay": 2, "Abs": 1}
         votes.sort(key=lambda v: order.get(v.get("myVote", "Abs"), 1),
                    reverse=reverse)
-    elif sort_col == 4:  # Vote Probability (mirrors data-impute-sort logic)
+    elif sort_col == 4:  # Vote Probability
+        # Votes without an estimated probability (abstentions on the member,
+        # lopsided votes where NOMINATE skips the estimate) always sink to the
+        # bottom, regardless of sort direction.
         def prob_key(v):
-            if "myProb" not in v:
-                return 0
             prob = int(round(v["myProb"]))
             return prob if v.get("myVote") == "Abs" else 1000 + prob
-        votes.sort(key=prob_key, reverse=reverse)
+        blanks = [v for v in votes if "myProb" not in v]
+        with_prob = [v for v in votes if "myProb" in v]
+        with_prob.sort(key=prob_key, reverse=reverse)
+        votes = with_prob + blanks
     elif sort_col == 5:  # Result (yea / total ratio, mirrors splitFunc)
         def result_key(v):
             yea = v.get("yea_count") or 0


### PR DESCRIPTION
## Summary
- When sorting a member's vote table by Vote Probability, votes lacking a `myProb` estimate (member abstentions, lopsided votes NOMINATE skips) now always sink to the bottom — in both ascending and descending sort directions — instead of clustering at the top of the descending sort.
- Splits the list into `with_prob` and `blanks`, sorts only the former, and appends blanks last.

## Test plan
- [ ] Open a member-votes page and sort by Vote Probability ascending; confirm rows with a probability appear first (low → high), blanks at the bottom.
- [ ] Re-sort descending; confirm rows with a probability appear first (high → low), blanks still at the bottom.
- [ ] Spot-check a member with many abstentions to confirm the blank block is contiguous and ordering of non-blank rows is unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)